### PR TITLE
inhibit hibernation on server and rnd only, no message on cli

### DIFF
--- a/src/pyshock/core/pyshock.py
+++ b/src/pyshock/core/pyshock.py
@@ -11,7 +11,6 @@ from pyshock.core.config import ConfigManager
 
 from pyshock.receiver.arshock import ArduinoManager
 from pyshock.receiver.pac import Pac
-from pyshock.util import powermanager
 
 class Pyshock:
     """This is the manager class. It basically coordinates everything and
@@ -155,8 +154,6 @@ class Pyshock:
         for receiver in self.receivers:
             receiver.boot(arduino_manager, sdr_sender)
 
-        powermanager.inhibit()
-
 
     def _process_command(self, receiver, action, power, duration):
         """sends a command to the indicated receiver
@@ -220,5 +217,4 @@ class PyshockMock(Pyshock):
             datefmt='%Y-%m-%d %H:%M:%S')
 
         self._setup_from_config()
-        powermanager.inhibit()
         print("Loaded mock")

--- a/src/pyshock/randomizer.py
+++ b/src/pyshock/randomizer.py
@@ -10,10 +10,11 @@ import random
 import sys
 import time
 
-
 from pyshock.core.pyshock import Pyshock, PyshockMock
 from pyshock.core.action import Action
 from pyshock.core.version import VERSION
+from pyshock.util import powermanager
+
 
 class PyshockRandomizer:
     """sends random commands at random intervals as configured"""
@@ -137,5 +138,6 @@ class PyshockRandomizer:
         self.__parse_args()
         self.__boot_pyshock()
         self.__load_config()
+        powermanager.inhibit()
         self.__test_receivers()
         self.__execute()

--- a/src/pyshock/server.py
+++ b/src/pyshock/server.py
@@ -19,6 +19,8 @@ import traceback
 from pyshock.core.pyshock import Pyshock, PyshockMock
 from pyshock.core.action import Action
 from pyshock.core.version import VERSION
+from pyshock.util import powermanager
+
 
 pyshock = None
 
@@ -192,4 +194,5 @@ class PyshockServer:
         """starts up pyshockserver"""
         self.__parse_args()
         self.__boot_pyshock()
+        powermanager.inhibit()
         self.__start_web_server()


### PR DESCRIPTION
Inhibiting hibernation is required for server and randomizer operation only. It does not make sense for a one-time command issued by the cli. It is actually hurtful because a message is displayed, if inhibiting fails